### PR TITLE
Use full name of keyword or symbol in clojure.walk/stringify-keys

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -1553,6 +1553,19 @@
   [^clojure.lang.Named x]
     (. x (getNamespace)))
 
+(defn full-name
+  "Returns the namespace/name String of a symbol or keyword,
+  or just name if namespace is not present."
+  {:tag String
+   :added "1.9"
+   :static true}
+  [^clojure.lang.Named x]
+    (let [x-namespace (namespace x)
+          x-name (name x)]
+      (if x-namespace
+        (str x-namespace "/" x-name)
+        x-name)))
+
 (defmacro locking
   "Executes exprs in an implicit do, while holding the monitor of x.
   Will release the monitor of x in all circumstances."

--- a/src/clj/clojure/walk.clj
+++ b/src/clj/clojure/walk.clj
@@ -102,7 +102,7 @@ the sorting function."}
   "Recursively transforms all map keys from keywords to strings."
   {:added "1.1"}
   [m]
-  (let [f (fn [[k v]] (if (keyword? k) [(name k) v] [k v]))]
+  (let [f (fn [[k v]] (if (keyword? k) [(full-name k) v] [k v]))]
     ;; only apply to maps
     (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
 

--- a/test/clojure/test_clojure/clojure_walk.clj
+++ b/test/clojure/test_clojure/clojure_walk.clj
@@ -11,8 +11,8 @@
          [:b {:b :b} (list 3 :c :b)])))
 
 (deftest t-stringify-keys
-  (is (= (w/stringify-keys {:a 1, nil {:b 2 :c 3}, :d 4})
-         {"a" 1, nil {"b" 2 "c" 3}, "d" 4})))
+  (is (= (w/stringify-keys {:a 1, nil {:b 2 :c 3}, :d 4, :e.f/g 5})
+         {"a" 1, nil {"b" 2 "c" 3}, "d" 4, "e.f/g" 5})))
 
 (deftest t-prewalk-order
   (is (= (let [a (atom [])]


### PR DESCRIPTION
- Add function clojure.core/full-name which returns full name of any
  named object containing namespace and name
- Use clojure.core/full-name in clojure.walk/stringify-keys
  instead of clojure.core/name as the latter one strips out
  the namespace part
